### PR TITLE
Restrict wildcard redirect URIs in realm configuration

### DIFF
--- a/webprotege.json
+++ b/webprotege.json
@@ -618,10 +618,10 @@
       "clientAuthenticatorType": "client-secret",
       "secret": "**********",
       "redirectUris": [
-        "/*"
+        "http://webprotege-local.edu/*"
       ],
       "webOrigins": [
-        "/*"
+        "http://webprotege-local.edu"
       ],
       "notBefore": 0,
       "bearerOnly": false,
@@ -943,9 +943,7 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "secret": "**********",
-      "redirectUris": [
-        "*"
-      ],
+      "redirectUris": [],
       "webOrigins": [],
       "notBefore": 0,
       "bearerOnly": false,
@@ -1168,12 +1166,8 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "secret": "**********",
-      "redirectUris": [
-        "/*"
-      ],
-      "webOrigins": [
-        "/*"
-      ],
+      "redirectUris": [],
+      "webOrigins": [],
       "notBefore": 0,
       "bearerOnly": false,
       "consentRequired": false,
@@ -1238,13 +1232,10 @@
       "alwaysDisplayInConsole": true,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "http://webprotege-local.edu/*",
-        "http://webprotege-local.edu*",
-        "http://webprotege-local.edu**",
-        "http://webprotege-local.edu/webprotege/*"
+        "http://webprotege-local.edu/*"
       ],
       "webOrigins": [
-        "http://webprotege-local.edu/webprotege"
+        "http://webprotege-local.edu"
       ],
       "notBefore": 0,
       "bearerOnly": false,


### PR DESCRIPTION
## Summary
- **Icatx_application**: Changed `redirectUris` from `["/*"]` to `["http://webprotege-local.edu/*"]` and `webOrigins` from `["/*"]` to `["http://webprotege-local.edu"]`
- **machine-client**: Removed wildcard `["*"]` redirect URI (service-account-only client, no redirect needed)
- **user-management**: Removed `["/*"]` redirect URI and web origin (service-account-only client, no redirect needed)
- **webprotege**: Removed redundant/double-wildcard entries (`http://webprotege-local.edu*`, `http://webprotege-local.edu**`), kept single explicit `http://webprotege-local.edu/*`; tightened `webOrigins` to `http://webprotege-local.edu`

Wildcard redirect URIs allow open redirect attacks — an attacker can craft a login URL that redirects the authorization code or token to a domain they control. This was flagged during review of protegeproject/webprotege-deploy#59.

## Test plan
- [x] Verify Keycloak starts and realm imports successfully
- [x] Verify login/redirect flow works for the webprotege client
- [x] Verify service-account clients (machine-client, user-management) can still obtain tokens via client credentials grant

🤖 Generated with [Claude Code](https://claude.com/claude-code)