### PR TITLE
Add startup entrypoint, multi-stage build, and aligned CI/CD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,13 @@
-name: Test
-
 on:
   push:
+    branches-ignore:
+      - main
   pull_request:
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
       - name: Build image

--- a/.github/workflows/notify-deploy-project.yaml
+++ b/.github/workflows/notify-deploy-project.yaml
@@ -1,0 +1,66 @@
+name: Notify WebProtege Deploy
+
+on:
+  workflow_call:
+    inputs:
+      service:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      branch_var:
+        required: true
+        type: string
+    secrets:
+      PROTEGE_PROJECT_CLIENT_ID:
+        required: true
+      PROTEGE_PROJECT_CLIENT_SECRET:
+        required: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PROTEGE_PROJECT_CLIENT_ID }}
+          private-key: ${{ secrets.PROTEGE_PROJECT_CLIENT_SECRET }}
+          owner: protegeproject
+          repositories: webprotege-deploy
+
+      - name: Trigger workflow_call in webprotege-deploy
+        run: |
+          SERVICE="${{ inputs.service }}"
+          VERSION="${{ inputs.version }}"
+          BRANCH="${{ inputs.branch_var }}"
+          echo "Triggering webprotege-deploy with service=$SERVICE and version=$VERSION"
+
+          response=$(curl -s -w "%{http_code}" -X POST \
+            -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/protegeproject/webprotege-deploy/actions/workflows/update-compose.yml/dispatches \
+            -d '{
+              "ref": "'"$BRANCH"'",
+              "inputs": {
+                "service": "'"$SERVICE"'",
+                "version": "'"$VERSION"'",
+                "branch": "'"$BRANCH"'"
+              }
+            }')
+
+          http_code=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | sed '$d')
+
+          echo "HTTP Status Code: $http_code"
+          echo "Response Body: $body"
+
+          if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+            echo "Error: API call failed with status code $http_code"
+            exit 1
+          else
+            echo "API call successful, status code: $http_code"
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,10 +30,8 @@ jobs:
         run: |
           VERSION=${{ steps.get-version.outputs.version }}
           find . -name 'pom.xml' -exec mvn versions:set -DnewVersion=$VERSION -DgenerateBackupPoms=false -f {} \;
-      - name: Build SPI plugin
-        run: mvn --batch-mode -pl spi clean package
       - name: Build and push Docker image
-        run: mvn --batch-mode package install
+        run: mvn --batch-mode install
       - name: Release
         uses: softprops/action-gh-release@v1
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,44 +2,103 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*.*.*'
+    branches:
+      - main
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'protegeproject-bot[bot]' }}
+    outputs:
+      version: ${{ steps.release-outputs.outputs.version }}
+      service: ${{ steps.release-outputs.outputs.service }}
+
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PROTEGEPROJECT_BOT_APP_ID }}
+          private-key: ${{ secrets.PROTEGEPROJECT_BOT_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
-      - name: Set up Java
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.head_ref }}
+      - name: Set up Maven Central Repository
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'adopt'
-      - name: Extract version from tag
+          server-id: docker.io
+          server-username: DOCKER_USERNAME
+          server-password: DOCKER_PASSWORD
+      - name: Get current version
         id: get-version
         run: |
-          VERSION=${GITHUB_REF_NAME#v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Version: $VERSION"
-      - name: Set version in pom.xml files
+          current_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Current version: $current_version"
+          echo "::set-output name=current_version::$current_version"
+      - name: Bump version
+        id: bump
         run: |
-          VERSION=${{ steps.get-version.outputs.version }}
-          find . -name 'pom.xml' -exec mvn versions:set -DnewVersion=$VERSION -DgenerateBackupPoms=false -f {} \;
-      - name: Build and push Docker image
-        run: mvn --batch-mode install
+          current_version=${{ steps.get-version.outputs.current_version }}
+          branch=${GITHUB_REF##*/}
+          echo "Current branch: $branch"
+
+          # Extract the base version without suffix
+          base_version=$(echo $current_version | sed -E 's/(-.*)?$//')
+
+          # Increment the base version (assuming semantic versioning)
+          IFS='.' read -r -a version_parts <<< "$base_version"
+          version_parts[2]=$((version_parts[2] + 1))
+          new_base_version="${version_parts[0]}.${version_parts[1]}.${version_parts[2]}"
+
+          echo "New version: $new_base_version"
+          find . -name 'pom.xml' -exec mvn versions:set -DnewVersion=$new_base_version -DgenerateBackupPoms=false -f {} \;
+          echo "::set-output name=new_base_version::$new_base_version"
+      - name: Commit new version
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Bump version to ${{ steps.bump.outputs.new_base_version }}"
+          git tag ${{ steps.bump.outputs.new_base_version }}
+          git push origin HEAD:${GITHUB_REF##*/}
+          git push origin ${{ steps.bump.outputs.new_base_version }}
+      - name: Build Docker image
+        run: mvn --batch-mode package
+      - name: Run entrypoint integration test
+        run: ./test-entrypoint.sh protegeproject/webprotege-keycloak:${{ steps.bump.outputs.new_base_version }}
+      - name: Push Docker image
+        run: docker push protegeproject/webprotege-keycloak:${{ steps.bump.outputs.new_base_version }}
       - name: Release
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ steps.bump.outputs.new_base_version }}
           generate_release_notes: true
 
+      - name: Set outputs
+        id: release-outputs
+        run: |
+          echo "version=${{ steps.bump.outputs.new_base_version }}" >> $GITHUB_OUTPUT
+          echo "service=webprotege-keycloak" >> $GITHUB_OUTPUT
+
+  notify-bump:
+    needs: build
+    uses: ./.github/workflows/notify-deploy-project.yaml
+    with:
+      version: ${{ needs.build.outputs.version }}
+      service: ${{ needs.build.outputs.service }}
+      branch_var: ${{vars.BUMP_WEBPROTEGE_BRANCH}}
+    secrets:
+      PROTEGE_PROJECT_CLIENT_ID: ${{ secrets.PROTEGE_PROJECT_CLIENT_ID }}
+      PROTEGE_PROJECT_CLIENT_SECRET: ${{ secrets.PROTEGE_PROJECT_CLIENT_SECRET }}
 
 env:
   DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,57 +36,74 @@ jobs:
           server-id: docker.io
           server-username: DOCKER_USERNAME
           server-password: DOCKER_PASSWORD
-      - name: Get current version
-        id: get-version
+
+      # Read the version from pom.xml and strip the -SNAPSHOT suffix to
+      # produce the release version.  For example, 2.0.0-SNAPSHOT becomes
+      # 2.0.0.  If there is no -SNAPSHOT suffix the version is used as-is.
+      - name: Determine release version
+        id: release-version
         run: |
           current_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "Current version: $current_version"
-          echo "::set-output name=current_version::$current_version"
-      - name: Bump version
-        id: bump
+          echo "Current pom version: $current_version"
+          release_version=$(echo "$current_version" | sed -E 's/-SNAPSHOT$//')
+          echo "Release version: $release_version"
+          echo "release_version=$release_version" >> $GITHUB_OUTPUT
+
+      # Set pom.xml to the release version (without -SNAPSHOT), commit,
+      # and tag.  This is the commit that the Docker image is built from.
+      - name: Set release version in pom.xml
         run: |
-          current_version=${{ steps.get-version.outputs.current_version }}
-          branch=${GITHUB_REF##*/}
-          echo "Current branch: $branch"
-
-          # Extract the base version without suffix
-          base_version=$(echo $current_version | sed -E 's/(-.*)?$//')
-
-          # Increment the base version (assuming semantic versioning)
-          IFS='.' read -r -a version_parts <<< "$base_version"
-          version_parts[2]=$((version_parts[2] + 1))
-          new_base_version="${version_parts[0]}.${version_parts[1]}.${version_parts[2]}"
-
-          echo "New version: $new_base_version"
-          find . -name 'pom.xml' -exec mvn versions:set -DnewVersion=$new_base_version -DgenerateBackupPoms=false -f {} \;
-          echo "::set-output name=new_base_version::$new_base_version"
-      - name: Commit new version
+          find . -name 'pom.xml' -exec mvn versions:set \
+            -DnewVersion=${{ steps.release-version.outputs.release_version }} \
+            -DgenerateBackupPoms=false -f {} \;
+      - name: Commit and tag release
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "Bump version to ${{ steps.bump.outputs.new_base_version }}"
-          git tag ${{ steps.bump.outputs.new_base_version }}
+          # If the pom already had the release version (no -SNAPSHOT suffix),
+          # there is nothing to commit — just tag the current HEAD.
+          git diff --cached --quiet || \
+            git commit -m "Release ${{ steps.release-version.outputs.release_version }}"
+          git tag ${{ steps.release-version.outputs.release_version }}
           git push origin HEAD:${GITHUB_REF##*/}
-          git push origin ${{ steps.bump.outputs.new_base_version }}
+          git push origin ${{ steps.release-version.outputs.release_version }}
+
       - name: Build Docker image
         run: mvn --batch-mode package
       - name: Run entrypoint integration test
-        run: ./test-entrypoint.sh protegeproject/webprotege-keycloak:${{ steps.bump.outputs.new_base_version }}
+        run: ./test-entrypoint.sh protegeproject/webprotege-keycloak:${{ steps.release-version.outputs.release_version }}
       - name: Push Docker image
-        run: docker push protegeproject/webprotege-keycloak:${{ steps.bump.outputs.new_base_version }}
+        run: docker push protegeproject/webprotege-keycloak:${{ steps.release-version.outputs.release_version }}
       - name: Release
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.bump.outputs.new_base_version }}
+          tag_name: ${{ steps.release-version.outputs.release_version }}
           generate_release_notes: true
+
+      # After the release, bump the patch version and add -SNAPSHOT to
+      # prepare the pom for the next development cycle.  For example,
+      # after releasing 2.0.0 the pom is set to 2.0.1-SNAPSHOT.
+      - name: Prepare next development version
+        run: |
+          released=${{ steps.release-version.outputs.release_version }}
+          IFS='.' read -r -a parts <<< "$released"
+          parts[2]=$((parts[2] + 1))
+          next_snapshot="${parts[0]}.${parts[1]}.${parts[2]}-SNAPSHOT"
+          echo "Next development version: $next_snapshot"
+          find . -name 'pom.xml' -exec mvn versions:set \
+            -DnewVersion=$next_snapshot \
+            -DgenerateBackupPoms=false -f {} \;
+          git add .
+          git commit -m "Prepare next development version ($next_snapshot)"
+          git push origin HEAD:${GITHUB_REF##*/}
 
       - name: Set outputs
         id: release-outputs
         run: |
-          echo "version=${{ steps.bump.outputs.new_base_version }}" >> $GITHUB_OUTPUT
+          echo "version=${{ steps.release-version.outputs.release_version }}" >> $GITHUB_OUTPUT
           echo "service=webprotege-keycloak" >> $GITHUB_OUTPUT
 
   notify-bump:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,15 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image
+        run: docker build -t protegeproject/webprotege-keycloak:test .
+      - name: Run entrypoint integration test
+        run: ./test-entrypoint.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Maven build output
 spi/target/
+*.versionsBackup
 
 # JVM
 hsperfdata_keycloak/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,23 @@
+FROM alpine:3 AS tools
+ARG TARGETARCH
+RUN wget -O /usr/local/bin/jq \
+      "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-${TARGETARCH}" \
+    && chmod +x /usr/local/bin/jq
+
+FROM maven:3.9-eclipse-temurin-17 AS spi-builder
+WORKDIR /build
+COPY spi/pom.xml .
+RUN mvn dependency:go-offline -B
+COPY spi/src ./src
+RUN mvn package -B -DskipTests
+
 FROM keycloak/keycloak:26.1
+COPY --from=tools /usr/local/bin/jq /usr/bin/jq
 COPY ./webprotege /opt/keycloak/themes/webprotege
-COPY ./spi/target/webprotege-credential-check-authenticator-*.jar /opt/keycloak/providers/
+COPY --from=spi-builder /build/target/webprotege-credential-check-authenticator-*.jar /opt/keycloak/providers/
 COPY ./webprotege.json /opt/keycloak/import/webprotege.json
+COPY --chmod=755 ./entrypoint.sh /opt/keycloak/bin/entrypoint.sh
+
 RUN /opt/keycloak/bin/kc.sh build
+
+ENTRYPOINT ["/opt/keycloak/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -72,6 +72,26 @@ staging, and production by setting `SERVER_HOST` in the deployment environment.
 | `KC_HTTP_RELATIVE_PATH` | Yes | *(none)* | Keycloak's HTTP relative path (e.g. `/keycloak`) |
 | `SERVER_HOST` | No | *(none)* | Public hostname; when set, client URIs and the realm frontend URL are updated to match |
 
+## Roles
+
+The realm defines a single application-level role on the `webprotege`
+client: **`SystemAdmin`**.  This is the bootstrap admin role for new
+installs — assigning it to a user grants full administrative access to
+WebProtege (manage application settings, create projects, edit roles,
+delete accounts, etc.).
+
+See the [webprotege-deploy README](../webprotege-deploy/README.md#first-admin-bootstrap)
+for step-by-step instructions on assigning the role to the first admin.
+
+All other authorization in WebProtege is managed inside the application
+itself via the authorization service's `RoleAssignment` collection and
+the Application Settings UI.  Keycloak roles are used only for the
+bootstrap admin — this keeps identity (Keycloak) and authorization
+(WebProtege) cleanly separated.
+
+Automating the initial admin assignment on fresh installs is tracked in
+[webprotege-authorization-service#36](https://github.com/protegeproject/webprotege-authorization-service/issues/36).
+
 ## Deployment
 
 For full deployment instructions, see the [webprotege-deploy README](../webprotege-deploy/README.md).

--- a/README.md
+++ b/README.md
@@ -8,39 +8,69 @@ Keycloak configuration for WebProtege. This repository contains:
 
 ## Prerequisites
 
-- Java 17+
-- Maven 3.8+
 - Docker
-
-## Building the Plugin
-
-The authenticator plugin must be built before deploying Keycloak:
-
-```bash
-cd spi
-mvn clean package
-```
-
-This produces `spi/target/webprotege-credential-check-authenticator-1.0.0.jar`.
 
 ## Docker Build
 
-The `Dockerfile` packages the theme, plugin, and realm configuration into a custom Keycloak image:
-
-```dockerfile
-FROM keycloak/keycloak:26.1
-COPY ./webprotege /opt/keycloak/themes/webprotege
-COPY ./spi/target/webprotege-credential-check-authenticator-1.0.0.jar /opt/keycloak/providers/
-COPY ./webprotege.json /opt/keycloak/import/webprotege.json
-RUN /opt/keycloak/bin/kc.sh build
-```
+The `Dockerfile` uses a multi-stage build to compile the authenticator plugin,
+download tools, and package the theme, realm configuration, and startup
+entrypoint into a custom Keycloak image.  No local Java or Maven installation
+is required.
 
 To build locally:
 
 ```bash
-cd spi && mvn clean package && cd ..
-docker build -t protegeproject/webprotege-keycloak:1.0.0 .
+docker build -t protegeproject/webprotege-keycloak:1.2.0 .
 ```
+
+## Startup Entrypoint
+
+The image includes a custom entrypoint script (`entrypoint.sh`) that wraps the
+standard Keycloak startup.  It starts Keycloak normally, waits for the realm
+import to complete, then applies two configuration patches that cannot be
+achieved through the realm import alone.
+
+### 1. Protocol Mapper Fix
+
+Keycloak's realm import mechanism has a known limitation: it silently drops the
+`config` dictionary for certain protocol mapper types.  The realm JSON defines a
+`username` mapper in the `profile` client scope that maps the custom user
+attribute `webprotege_username` to the `preferred_username` JWT claim.  After
+import, Keycloak reverts this mapper to its built-in default, which maps the
+Keycloak username field instead.
+
+This matters because WebProtege uses email addresses as Keycloak usernames, but
+internal application lookups rely on the original MongoDB user ID stored in the
+`webprotege_username` attribute.  Without the fix, the backend receives email
+addresses where it expects user IDs, breaking user resolution.
+
+The entrypoint detects this condition on each startup and, if the mapper is in
+the wrong state, deletes it and recreates it with the correct configuration.
+On subsequent boots where the mapper is already correct, the fix is skipped.
+
+### 2. Hostname-Based Client URI Patching
+
+The realm JSON ships with a default hostname baked into the `webprotege`
+client's redirect URIs, web origins, and base URL.  Self-hosted deployments use
+different hostnames.  When the `SERVER_HOST` environment variable is set, the
+entrypoint updates these values so that:
+
+- Keycloak accepts OAuth redirects back to the correct host
+- CORS headers include the correct origin
+- The Keycloak login and account pages link back to the correct application URL
+- The realm's OpenID Connect discovery document advertises the correct issuer
+
+This makes the image portable — the same build works for local development,
+staging, and production by setting `SERVER_HOST` in the deployment environment.
+
+### Environment Variables
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `KEYCLOAK_ADMIN` | Yes | `admin` | Admin username for kcadm authentication |
+| `KEYCLOAK_ADMIN_PASSWORD` | Yes | `password` | Admin password for kcadm authentication |
+| `KC_HTTP_RELATIVE_PATH` | Yes | *(none)* | Keycloak's HTTP relative path (e.g. `/keycloak`) |
+| `SERVER_HOST` | No | *(none)* | Public hostname; when set, client URIs and the realm frontend URL are updated to match |
 
 ## Deployment
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,333 @@
+#!/bin/bash
+# =============================================================================
+# WebProtege Keycloak Entrypoint
+# =============================================================================
+#
+# This script wraps the standard Keycloak startup to apply realm configuration
+# fixes that cannot be achieved through the normal realm import mechanism alone.
+#
+# WHY THIS EXISTS
+# ---------------
+# WebProtege ships a realm JSON file (webprotege.json) that is imported
+# automatically by Keycloak on first boot via the /opt/keycloak/import/
+# directory.  Two problems prevent the imported realm from being correct
+# out of the box:
+#
+#   1. PROTOCOL MAPPER BUG — Keycloak's realm import silently drops the
+#      'config' dictionary for certain protocol mapper types.  The realm
+#      JSON defines a 'username' mapper in the 'profile' client scope that
+#      maps the custom user attribute 'webprotege_username' to the JWT claim
+#      'preferred_username'.  After import, Keycloak reverts this mapper to
+#      its built-in default, which maps the Keycloak username field instead.
+#
+#      This matters because WebProtege uses email addresses as Keycloak
+#      usernames, but internal application lookups rely on the original
+#      MongoDB user ID stored in the 'webprotege_username' attribute.
+#      Without this fix, the backend receives email addresses where it
+#      expects user IDs, breaking user resolution.
+#
+#      See also:
+#        https://github.com/keycloak/keycloak/issues/36065
+#          (client scope PUT silently ignores protocolMappers — by design)
+#        https://github.com/keycloak/keycloak/issues/16289
+#          (partial realm import ignores clientScopes entirely — still open)
+#
+#   2. HARDCODED HOSTNAMES — The realm JSON contains client redirect URIs,
+#      web origins, and a realm-level frontend URL that reference a specific
+#      hostname (e.g. 'webprotege-local.edu').  Self-hosted deployments use
+#      different hostnames.  Rather than requiring operators to manually edit
+#      the realm JSON or run kcadm commands after startup, this script reads
+#      the SERVER_HOST environment variable and patches these values
+#      automatically, making the image portable across environments.
+#
+# HOW IT WORKS
+# ------------
+#   1. Keycloak is started in the background (the normal kc.sh process).
+#   2. The script waits for Keycloak to become healthy by authenticating
+#      to the Admin CLI against the master realm.
+#   3. It checks whether the 'webprotege' realm exists.  If not, it
+#      imports it from the baked-in realm JSON via kcadm.  (Keycloak does
+#      not auto-import from /opt/keycloak/import/ — only from
+#      /opt/keycloak/data/import/ with the --import-realm flag.  We use
+#      explicit kcadm import for full control over the process.)
+#   4. It checks and, if necessary, fixes the username protocol mapper.
+#   5. If SERVER_HOST is set, it updates client URIs and the realm frontend
+#      URL to match.
+#   6. Control is handed back to the Keycloak process, which remains the
+#      container's foreground process for the rest of its lifecycle.
+#
+# IDEMPOTENCY
+# -----------
+# Every patch is guarded by a check.  On subsequent container restarts
+# (where the realm already exists in Keycloak's persistent storage and the
+# mapper was fixed on a previous boot), the script detects the correct state
+# and skips the modification.  This means the script is safe to run on every
+# startup without side effects.
+#
+# SIGNAL HANDLING
+# ---------------
+# SIGTERM and SIGINT are forwarded to the Keycloak background process so
+# that 'docker compose stop' triggers a graceful Keycloak shutdown rather
+# than killing the wrapper script and orphaning the Java process.
+#
+# REQUIRED ENVIRONMENT VARIABLES
+# ------------------------------
+#   KEYCLOAK_ADMIN          — Admin username (default: 'admin')
+#   KEYCLOAK_ADMIN_PASSWORD — Admin password (default: 'password')
+#   KC_HTTP_RELATIVE_PATH   — Keycloak's HTTP relative path, used to
+#                             construct the admin server URL (e.g. '/keycloak')
+#
+# OPTIONAL ENVIRONMENT VARIABLES
+# ------------------------------
+#   SERVER_HOST — The public hostname for this deployment (e.g.
+#                 'webproteg.local', 'webprotege.example.org').  When set,
+#                 the script updates the 'webprotege' client's redirect URIs,
+#                 web origins, base URL, and the realm's frontend URL to
+#                 match.  When omitted, URI patching is skipped and the
+#                 realm retains whatever values it was imported with.
+#
+# DEPENDENCIES
+# ------------
+#   jq — Installed in the Docker image via a multi-stage build that
+#        downloads the static binary from the jq GitHub releases.  Used
+#        to parse JSON responses from kcadm.sh when extracting IDs and
+#        checking config.
+#
+# =============================================================================
+
+set -euo pipefail
+
+KCADM="/opt/keycloak/bin/kcadm.sh"
+KC_RELATIVE_PATH="${KC_HTTP_RELATIVE_PATH:-}"
+KC_SERVER="http://localhost:8080${KC_RELATIVE_PATH}"
+KC_ADMIN="${KEYCLOAK_ADMIN:-admin}"
+KC_ADMIN_PW="${KEYCLOAK_ADMIN_PASSWORD:-password}"
+
+# If no command is provided (e.g. compose omits the 'command' directive),
+# default to 'start-dev' which is the standard Keycloak development mode.
+if [ $# -eq 0 ]; then
+  set -- start-dev
+fi
+
+# ---------------------------------------------------------------------------
+# Start Keycloak in the background.
+#
+# The arguments ($@) are passed through from Docker — typically 'start-dev'
+# via the compose command directive.  Running in the background allows this
+# script to perform post-import patching while Keycloak is initialising.
+# ---------------------------------------------------------------------------
+/opt/keycloak/bin/kc.sh "$@" &
+KC_PID=$!
+
+# Forward SIGTERM/SIGINT to the Keycloak process.  Without this, Docker's
+# stop signal would kill the wrapper script but leave the Java process
+# running until the container is forcefully terminated.
+trap 'kill -TERM $KC_PID 2>/dev/null; wait $KC_PID; exit $?' TERM INT
+
+# ---------------------------------------------------------------------------
+# Wait for Keycloak to be ready.
+#
+# We wait for the Keycloak HTTP server to be accepting admin API requests.
+# The check authenticates against the master realm — once this succeeds we
+# know the server is fully initialised and can accept kcadm commands.
+#
+# The loop retries every 2 seconds for up to MAX_RETRIES attempts.  If
+# Keycloak fails to start in time, the script logs an error but does NOT
+# crash the container — Keycloak continues running, just without the realm
+# setup.
+# ---------------------------------------------------------------------------
+echo "[entrypoint] Waiting for Keycloak to start..."
+MAX_RETRIES=60
+RETRY=0
+until $KCADM config credentials \
+        --server "$KC_SERVER" \
+        --realm master \
+        --user "$KC_ADMIN" \
+        --password "$KC_ADMIN_PW" 2>/dev/null; do
+  RETRY=$((RETRY + 1))
+  if [ $RETRY -ge $MAX_RETRIES ]; then
+    echo "[entrypoint] ERROR: Keycloak did not become ready within $((MAX_RETRIES * 2))s."
+    echo "[entrypoint] Realm setup has been skipped.  Keycloak will continue running"
+    echo "[entrypoint] but the webprotege realm may be missing or misconfigured."
+    echo "[entrypoint] Check the Keycloak logs above for startup errors."
+    wait $KC_PID
+    exit $?
+  fi
+  sleep 2
+done
+
+echo "[entrypoint] Keycloak is ready."
+
+# ---------------------------------------------------------------------------
+# Import the webprotege realm if it does not already exist.
+#
+# The realm JSON is baked into the image at /opt/keycloak/import/.  Keycloak
+# does NOT auto-import from this path — the file is imported explicitly here
+# via kcadm on first boot.  On subsequent boots (where the realm already
+# exists in Keycloak's persistent H2 database), this step is skipped.
+# ---------------------------------------------------------------------------
+REALM_JSON="/opt/keycloak/import/webprotege.json"
+
+if $KCADM get realms/webprotege >/dev/null 2>&1; then
+  echo "[entrypoint] Realm 'webprotege' already exists. Skipping import."
+else
+  echo "[entrypoint] Realm 'webprotege' not found. Importing from ${REALM_JSON}..."
+  if [ ! -f "$REALM_JSON" ]; then
+    echo "[entrypoint] ERROR: Realm file not found at ${REALM_JSON}. Cannot import."
+    wait $KC_PID
+    exit $?
+  fi
+  $KCADM create realms -f "$REALM_JSON"
+  echo "[entrypoint] Realm 'webprotege' imported successfully."
+fi
+
+echo "[entrypoint] Checking realm configuration..."
+
+# ---------------------------------------------------------------------------
+# fix_username_mapper
+#
+# Detects and fixes the 'username' protocol mapper in the 'profile' client
+# scope.  See the "PROTOCOL MAPPER BUG" section in the header for context.
+#
+# Steps:
+#   1. Look up the internal ID of the 'profile' client scope.
+#   2. Within that scope, look up the internal ID of the 'username' mapper.
+#   3. Read the mapper's current config and check whether 'user.attribute'
+#      is already set to 'webprotege_username'.
+#   4. If yes  -> do nothing (already correct, either from a previous boot
+#                 or because a future Keycloak version fixes the import bug).
+#      If no   -> delete the broken mapper and recreate it with the correct
+#                 configuration.
+#
+# The delete-then-create approach (rather than an in-place update) is used
+# because kcadm does not reliably support partial updates to protocol mapper
+# config fields.
+# ---------------------------------------------------------------------------
+fix_username_mapper() {
+  local scope_id mapper_id current_attr
+
+  # Step 1: Find the 'profile' client scope ID
+  scope_id=$($KCADM get client-scopes -r webprotege --fields id,name \
+    | jq -r '.[] | select(.name == "profile") | .id')
+
+  if [ -z "$scope_id" ]; then
+    echo "[entrypoint] WARNING: 'profile' client scope not found. Skipping mapper fix."
+    return
+  fi
+
+  # Step 2: Find the 'username' mapper ID within the profile scope
+  mapper_id=$($KCADM get "client-scopes/$scope_id/protocol-mappers/models" \
+    -r webprotege --fields id,name \
+    | jq -r '.[] | select(.name == "username") | .id')
+
+  if [ -z "$mapper_id" ]; then
+    echo "[entrypoint] WARNING: 'username' mapper not found in profile scope. Skipping."
+    return
+  fi
+
+  # Step 3: Check current state — skip if already correct
+  current_attr=$($KCADM get \
+    "client-scopes/$scope_id/protocol-mappers/models/$mapper_id" \
+    -r webprotege | jq -r '.config["user.attribute"] // empty')
+
+  if [ "$current_attr" = "webprotege_username" ]; then
+    echo "[entrypoint] Username mapper already correct. Skipping."
+    return
+  fi
+
+  # Step 4: Delete the broken mapper and recreate with the correct config
+  echo "[entrypoint] Fixing username mapper (current user.attribute: '${current_attr:-<empty>}')..."
+
+  $KCADM delete \
+    "client-scopes/$scope_id/protocol-mappers/models/$mapper_id" \
+    -r webprotege
+
+  $KCADM create \
+    "client-scopes/$scope_id/protocol-mappers/models" \
+    -r webprotege \
+    -s name=username \
+    -s protocol=openid-connect \
+    -s protocolMapper=oidc-usermodel-attribute-mapper \
+    -s consentRequired=false \
+    -s 'config."user.attribute"=webprotege_username' \
+    -s 'config."id.token.claim"=true' \
+    -s 'config."access.token.claim"=true' \
+    -s 'config."claim.name"=preferred_username' \
+    -s 'config."jsonType.label"=String' \
+    -s 'config."userinfo.token.claim"=true'
+
+  echo "[entrypoint] Username mapper fixed successfully."
+}
+
+# ---------------------------------------------------------------------------
+# update_client_uris
+#
+# Updates the 'webprotege' Keycloak client and the realm-level frontend URL
+# to match the current SERVER_HOST value.  See the "HARDCODED HOSTNAMES"
+# section in the header for context.
+#
+# The realm JSON ships with a default hostname baked into redirect URIs, web
+# origins, and the base URL.  Self-hosted deployments will have a different
+# hostname.  This function overwrites those values so that:
+#
+#   - Keycloak accepts OAuth redirects back to the correct host
+#   - CORS headers include the correct origin
+#   - The Keycloak account console and login pages link back to the correct
+#     application URL
+#
+# This runs on every startup (not just first boot) because SERVER_HOST may
+# change between restarts — e.g. switching from local dev to a staging
+# hostname.  The kcadm 'update' command is a PUT, so applying the same
+# values twice is harmless.
+#
+# Skipped entirely if SERVER_HOST is not set, allowing the realm to retain
+# whatever values it was imported with.
+# ---------------------------------------------------------------------------
+update_client_uris() {
+  if [ -z "${SERVER_HOST:-}" ]; then
+    echo "[entrypoint] SERVER_HOST not set. Skipping client URI update."
+    return
+  fi
+
+  local client_id
+
+  # Find the internal ID of the 'webprotege' client
+  client_id=$($KCADM get clients -r webprotege --fields id,clientId \
+    | jq -r '.[] | select(.clientId == "webprotege") | .id')
+
+  if [ -z "$client_id" ]; then
+    echo "[entrypoint] WARNING: 'webprotege' client not found. Skipping URI update."
+    return
+  fi
+
+  # Update the client's base URL, redirect URI whitelist, and allowed web origins
+  echo "[entrypoint] Updating webprotege client URIs for SERVER_HOST=${SERVER_HOST}..."
+
+  $KCADM update "clients/$client_id" -r webprotege \
+    -s "baseUrl=http://${SERVER_HOST}" \
+    -s "redirectUris=[\"http://${SERVER_HOST}/*\",\"http://${SERVER_HOST}/webprotege/*\"]" \
+    -s "webOrigins=[\"http://${SERVER_HOST}/webprotege\"]"
+
+  # Update the realm-level frontend URL.  This controls URLs that Keycloak
+  # generates in emails, account console links, and the OpenID Connect
+  # discovery document.
+  echo "[entrypoint] Updating realm frontend URL..."
+  $KCADM update realms/webprotege \
+    -s "attributes.frontendUrl=http://${SERVER_HOST}/keycloak"
+
+  echo "[entrypoint] Client URIs and frontend URL updated for ${SERVER_HOST}."
+}
+
+# ---------------------------------------------------------------------------
+# Apply the patches and hand control back to Keycloak.
+# ---------------------------------------------------------------------------
+fix_username_mapper
+update_client_uris
+
+echo "[entrypoint] Realm configuration complete."
+
+# Wait for the Keycloak process.  This keeps the script (and therefore the
+# container) alive for as long as Keycloak is running.  When Keycloak exits
+# (either normally or via the signal trap above), the script exits with
+# Keycloak's exit code.
+wait $KC_PID

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -202,6 +202,12 @@ echo "[entrypoint] Checking realm configuration..."
 # The delete-then-create approach (rather than an in-place update) is used
 # because kcadm does not reliably support partial updates to protocol mapper
 # config fields.
+#
+# Note: this mapper maps the 'webprotege_username' user attribute to the
+# 'preferred_username' JWT claim.  The attribute is set by the legacy user
+# migration process for migrated users, and by the
+# WebprotegeUsernameAttributeEventListener SPI for newly registered users
+# (which sets the attribute to the Keycloak username at registration time).
 # ---------------------------------------------------------------------------
 fix_username_mapper() {
   local scope_id mapper_id current_attr

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>edu.stanford.webprotege</groupId>
     <artifactId>webprotege-keycloak</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.1</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>edu.stanford.webprotege</groupId>
     <artifactId>webprotege-keycloak</artifactId>
-    <version>1.1.1</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/spi/src/main/java/edu/stanford/webprotege/keycloak/WebprotegeUsernameAttributeEventListener.java
+++ b/spi/src/main/java/edu/stanford/webprotege/keycloak/WebprotegeUsernameAttributeEventListener.java
@@ -1,0 +1,96 @@
+package edu.stanford.webprotege.keycloak;
+
+import org.keycloak.events.Event;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventType;
+import org.keycloak.events.admin.AdminEvent;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Event listener that populates the {@code webprotege_username} user attribute
+ * on newly registered users.
+ *
+ * <p>Background: the WebProtege stack uses a custom protocol mapper that maps
+ * the {@code webprotege_username} user attribute to the {@code preferred_username}
+ * JWT claim.  The mapper was introduced to support legacy users migrated from
+ * pre-Keycloak WebProtege — those users have their original MongoDB user ID
+ * stored in the {@code webprotege_username} attribute, which the backend
+ * services use for user lookup.
+ *
+ * <p>For newly registered Keycloak users the attribute does not exist, so the
+ * {@code preferred_username} claim would be absent from the JWT.  The API
+ * gateway requires this claim to identify the user and rejects requests without
+ * it (returning a 400 Bad Request with a {@code User null} log line).
+ *
+ * <p>This listener watches for {@link EventType#REGISTER} events and sets the
+ * {@code webprotege_username} attribute to the Keycloak username for any
+ * newly registered user who does not already have the attribute.  Migrated
+ * users are unaffected because their attribute is already populated.
+ */
+public class WebprotegeUsernameAttributeEventListener implements EventListenerProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(
+            WebprotegeUsernameAttributeEventListener.class);
+
+    private static final String ATTRIBUTE_NAME = "webprotege_username";
+
+    private final KeycloakSession session;
+
+    public WebprotegeUsernameAttributeEventListener(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public void onEvent(Event event) {
+        if (event.getType() != EventType.REGISTER) {
+            return;
+        }
+
+        String realmId = event.getRealmId();
+        String userId = event.getUserId();
+        if (realmId == null || userId == null) {
+            return;
+        }
+
+        RealmModel realm = session.realms().getRealm(realmId);
+        if (realm == null) {
+            return;
+        }
+
+        UserModel user = session.users().getUserById(realm, userId);
+        if (user == null) {
+            return;
+        }
+
+        // Don't overwrite an existing value — migrated users may already have
+        // this attribute set to their legacy MongoDB user ID.
+        String existing = user.getFirstAttribute(ATTRIBUTE_NAME);
+        if (existing != null && !existing.isEmpty()) {
+            return;
+        }
+
+        String username = user.getUsername();
+        if (username == null || username.isEmpty()) {
+            logger.warn("Registered user {} has no username; cannot set {} attribute",
+                    userId, ATTRIBUTE_NAME);
+            return;
+        }
+
+        user.setSingleAttribute(ATTRIBUTE_NAME, username);
+        logger.info("Set {}={} on newly registered user {}", ATTRIBUTE_NAME, username, userId);
+    }
+
+    @Override
+    public void onEvent(AdminEvent event, boolean includeRepresentation) {
+        // Not interested in admin events.
+    }
+
+    @Override
+    public void close() {
+        // Nothing to clean up.
+    }
+}

--- a/spi/src/main/java/edu/stanford/webprotege/keycloak/WebprotegeUsernameAttributeEventListenerFactory.java
+++ b/spi/src/main/java/edu/stanford/webprotege/keycloak/WebprotegeUsernameAttributeEventListenerFactory.java
@@ -1,0 +1,45 @@
+package edu.stanford.webprotege.keycloak;
+
+import org.keycloak.Config;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventListenerProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+/**
+ * Factory that creates {@link WebprotegeUsernameAttributeEventListener} instances.
+ *
+ * <p>Registered via {@code META-INF/services/org.keycloak.events.EventListenerProviderFactory}
+ * so that Keycloak discovers it during startup.  This factory must be listed in
+ * the realm's {@code eventsListeners} configuration (set in the realm JSON) for
+ * the listener to receive events.
+ */
+public class WebprotegeUsernameAttributeEventListenerFactory implements EventListenerProviderFactory {
+
+    public static final String PROVIDER_ID = "webprotege-username-attribute";
+
+    @Override
+    public EventListenerProvider create(KeycloakSession session) {
+        return new WebprotegeUsernameAttributeEventListener(session);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+        // No configuration required.
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+        // Nothing to do after init.
+    }
+
+    @Override
+    public void close() {
+        // Nothing to clean up.
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/spi/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
+++ b/spi/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
@@ -1,0 +1,1 @@
+edu.stanford.webprotege.keycloak.WebprotegeUsernameAttributeEventListenerFactory

--- a/test-entrypoint.sh
+++ b/test-entrypoint.sh
@@ -1,0 +1,433 @@
+#!/bin/bash
+# =============================================================================
+# Integration Test for the WebProtege Keycloak Entrypoint
+# =============================================================================
+#
+# This script verifies that the custom entrypoint (entrypoint.sh) correctly:
+#
+#   1. Imports the 'webprotege' realm on first boot.
+#   2. Configures the 'username' protocol mapper to map the custom user
+#      attribute 'webprotege_username' to the JWT claim 'preferred_username'.
+#   3. Rewrites client redirect URIs, web origins, base URL, and the realm
+#      frontend URL to match the SERVER_HOST environment variable.
+#   4. Behaves idempotently on restart — skips realm import when the realm
+#      already exists, skips mapper fix when already correct, and re-applies
+#      URI updates harmlessly.
+#
+# PREREQUISITES
+# -------------
+#   - Docker daemon running
+#   - jq installed on the host (used to parse kcadm JSON responses)
+#   - The Docker image must be built before running this script:
+#       docker build -t protegeproject/webprotege-keycloak:test .
+#
+# USAGE
+# -----
+#   ./test-entrypoint.sh [image]
+#
+#   image — Docker image to test (default: protegeproject/webprotege-keycloak:test)
+#
+# EXIT CODES
+# ----------
+#   0 — All tests passed
+#   1 — One or more tests failed
+#
+# CLEANUP
+# -------
+#   The script removes its container and volume on exit (including on failure
+#   or Ctrl+C) via a trap handler.  If you need to inspect a failed container,
+#   comment out the cleanup() call in the trap.
+#
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+IMAGE="${1:-protegeproject/webprotege-keycloak:test}"
+CONTAINER_NAME="keycloak-entrypoint-test"
+VOLUME_NAME="keycloak-entrypoint-test-data"
+TEST_HOST="test.example.com"
+
+# Keycloak admin credentials — must match the defaults in entrypoint.sh
+KC_ADMIN="admin"
+KC_ADMIN_PW="password"
+KC_RELATIVE_PATH="/keycloak"
+
+# How long to wait for the entrypoint to complete before failing (seconds)
+TIMEOUT=120
+
+# ---------------------------------------------------------------------------
+# Colours for test output (disabled if stdout is not a terminal)
+# ---------------------------------------------------------------------------
+
+if [ -t 1 ]; then
+  GREEN='\033[0;32m'
+  RED='\033[0;31m'
+  YELLOW='\033[0;33m'
+  NC='\033[0m'
+else
+  GREEN='' RED='' YELLOW='' NC=''
+fi
+
+# ---------------------------------------------------------------------------
+# Counters
+# ---------------------------------------------------------------------------
+
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# cleanup
+#
+# Removes the test container and volume.  Called automatically on exit via
+# trap, ensuring resources are freed even when a test fails or the script
+# is interrupted.
+# ---------------------------------------------------------------------------
+cleanup() {
+  echo ""
+  echo "Cleaning up..."
+  docker stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  docker rm "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  docker volume rm "$VOLUME_NAME" >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+# assert_eq <description> <expected> <actual>
+#
+# Compares two values and reports pass/fail.  On failure, prints both values
+# so you can see what went wrong without re-running.
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo -e "        expected: ${expected}"
+    echo -e "        actual:   ${actual}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# assert_contains <description> <substring> <haystack>
+#
+# Checks that a string contains the expected substring.  Useful for
+# assertions on multi-line output where exact matching is fragile.
+assert_contains() {
+  local desc="$1" substring="$2" haystack="$3"
+  if echo "$haystack" | grep -q "$substring"; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo -e "        expected to contain: ${substring}"
+    echo -e "        actual output:       ${haystack}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# wait_for_entrypoint
+#
+# Blocks until the entrypoint prints its completion message, or until
+# TIMEOUT seconds have elapsed.  Returns 0 on success, 1 on timeout.
+wait_for_entrypoint() {
+  local elapsed=0
+  while [ $elapsed -lt $TIMEOUT ]; do
+    if docker logs "$CONTAINER_NAME" 2>&1 | grep -q "\[entrypoint\] Realm configuration complete"; then
+      return 0
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  echo -e "${RED}ERROR: Entrypoint did not complete within ${TIMEOUT}s${NC}"
+  echo "Container logs:"
+  docker logs "$CONTAINER_NAME" 2>&1 | tail -30
+  return 1
+}
+
+# wait_for_entrypoint_count <n>
+#
+# Blocks until the entrypoint completion message has appeared at least <n>
+# times in the container logs.  Used after a restart to wait for the second
+# boot's entrypoint to finish.
+wait_for_entrypoint_count() {
+  local target="$1" elapsed=0
+  while [ $elapsed -lt $TIMEOUT ]; do
+    local count
+    count=$(docker logs "$CONTAINER_NAME" 2>&1 | grep -c "\[entrypoint\] Realm configuration complete" || true)
+    if [ "$count" -ge "$target" ]; then
+      return 0
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  echo -e "${RED}ERROR: Entrypoint completion #${target} not reached within ${TIMEOUT}s${NC}"
+  docker logs "$CONTAINER_NAME" 2>&1 | tail -30
+  return 1
+}
+
+# kcadm <args...>
+#
+# Runs a kcadm.sh command inside the test container.  Authenticates against
+# the master realm first (kcadm requires a session per invocation when run
+# via docker exec without a persistent kcadm config directory).
+kcadm() {
+  docker exec "$CONTAINER_NAME" /opt/keycloak/bin/kcadm.sh \
+    config credentials \
+    --server "http://localhost:8080${KC_RELATIVE_PATH}" \
+    --realm master \
+    --user "$KC_ADMIN" \
+    --password "$KC_ADMIN_PW" 2>/dev/null
+
+  docker exec "$CONTAINER_NAME" /opt/keycloak/bin/kcadm.sh "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Preflight checks
+# ---------------------------------------------------------------------------
+
+echo "=== Preflight checks ==="
+
+# Verify jq is available on the host
+if ! command -v jq &>/dev/null; then
+  echo -e "${RED}ERROR: jq is required but not installed.${NC}"
+  echo "Install it with: brew install jq (macOS) or apt install jq (Debian/Ubuntu)"
+  exit 1
+fi
+
+# Verify the Docker image exists
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  echo -e "${RED}ERROR: Docker image '${IMAGE}' not found.${NC}"
+  echo "Build it first with: docker build -t ${IMAGE} ."
+  exit 1
+fi
+
+echo -e "  Image: ${IMAGE}"
+echo -e "  Test host: ${TEST_HOST}"
+echo ""
+
+# ===========================================================================
+# TEST PHASE 1: First boot
+# ===========================================================================
+
+echo "=== Phase 1: First boot ==="
+echo "Starting container..."
+
+# Remove any leftovers from a previous failed run
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+docker volume rm "$VOLUME_NAME" >/dev/null 2>&1 || true
+
+# Start with a named volume so data persists across the restart in Phase 2.
+# No host port is published — all kcadm assertions run inside the container
+# via 'docker exec', so there is no port conflict risk on the host.
+# SERVER_HOST is set to our test hostname so the URI patching runs.
+docker run -d \
+  --name "$CONTAINER_NAME" \
+  -v "${VOLUME_NAME}:/opt/keycloak/data" \
+  -e KEYCLOAK_ADMIN="$KC_ADMIN" \
+  -e KEYCLOAK_ADMIN_PASSWORD="$KC_ADMIN_PW" \
+  -e KC_HTTP_RELATIVE_PATH="$KC_RELATIVE_PATH" \
+  -e SERVER_HOST="$TEST_HOST" \
+  "$IMAGE" \
+  start-dev >/dev/null
+
+echo "Waiting for entrypoint to complete..."
+if ! wait_for_entrypoint; then
+  exit 1
+fi
+
+# --- Check entrypoint log messages ---
+
+LOGS=$(docker logs "$CONTAINER_NAME" 2>&1)
+ENTRYPOINT_LOGS=$(echo "$LOGS" | grep "\[entrypoint\]")
+
+echo ""
+echo "--- Entrypoint log assertions ---"
+
+assert_contains \
+  "Realm was imported on first boot" \
+  "Realm 'webprotege' imported successfully" \
+  "$ENTRYPOINT_LOGS"
+
+assert_contains \
+  "Entrypoint completed" \
+  "Realm configuration complete" \
+  "$ENTRYPOINT_LOGS"
+
+# --- Check the username protocol mapper ---
+#
+# The mapper in the 'profile' client scope should map the custom user
+# attribute 'webprotege_username' to the 'preferred_username' JWT claim
+# using the 'oidc-usermodel-attribute-mapper' protocol mapper type.
+
+echo ""
+echo "--- Mapper assertions ---"
+
+PROFILE_SCOPE_ID=$(kcadm get client-scopes -r webprotege --fields id,name \
+  | jq -r '.[] | select(.name == "profile") | .id')
+
+MAPPER_ID=$(kcadm get "client-scopes/$PROFILE_SCOPE_ID/protocol-mappers/models" \
+  -r webprotege --fields id,name \
+  | jq -r '.[] | select(.name == "username") | .id')
+
+MAPPER_JSON=$(kcadm get \
+  "client-scopes/$PROFILE_SCOPE_ID/protocol-mappers/models/$MAPPER_ID" \
+  -r webprotege)
+
+assert_eq \
+  "Mapper type is oidc-usermodel-attribute-mapper" \
+  "oidc-usermodel-attribute-mapper" \
+  "$(echo "$MAPPER_JSON" | jq -r '.protocolMapper')"
+
+assert_eq \
+  "Mapper user.attribute is webprotege_username" \
+  "webprotege_username" \
+  "$(echo "$MAPPER_JSON" | jq -r '.config["user.attribute"]')"
+
+assert_eq \
+  "Mapper claim.name is preferred_username" \
+  "preferred_username" \
+  "$(echo "$MAPPER_JSON" | jq -r '.config["claim.name"]')"
+
+# --- Check client URIs ---
+#
+# The 'webprotege' client's baseUrl, redirectUris, and webOrigins should
+# all reference the TEST_HOST hostname, not the hardcoded default from
+# the realm JSON.
+
+echo ""
+echo "--- Client URI assertions ---"
+
+CLIENT_ID=$(kcadm get clients -r webprotege --fields id,clientId \
+  | jq -r '.[] | select(.clientId == "webprotege") | .id')
+
+CLIENT_JSON=$(kcadm get "clients/$CLIENT_ID" \
+  -r webprotege --fields baseUrl,redirectUris,webOrigins)
+
+assert_eq \
+  "Client baseUrl uses SERVER_HOST" \
+  "http://${TEST_HOST}" \
+  "$(echo "$CLIENT_JSON" | jq -r '.baseUrl')"
+
+assert_contains \
+  "Client redirectUris includes SERVER_HOST wildcard" \
+  "http://${TEST_HOST}/*" \
+  "$(echo "$CLIENT_JSON" | jq -r '.redirectUris[]')"
+
+assert_contains \
+  "Client webOrigins includes SERVER_HOST" \
+  "http://${TEST_HOST}/webprotege" \
+  "$(echo "$CLIENT_JSON" | jq -r '.webOrigins[]')"
+
+# --- Check realm frontend URL ---
+
+echo ""
+echo "--- Realm frontend URL assertion ---"
+
+FRONTEND_URL=$(kcadm get realms/webprotege --fields 'attributes(frontendUrl)' \
+  | jq -r '.attributes.frontendUrl')
+
+assert_eq \
+  "Realm frontendUrl uses SERVER_HOST" \
+  "http://${TEST_HOST}/keycloak" \
+  "$FRONTEND_URL"
+
+# ===========================================================================
+# TEST PHASE 2: Restart (idempotency)
+# ===========================================================================
+
+echo ""
+echo "=== Phase 2: Restart (idempotency) ==="
+echo "Restarting container..."
+
+docker restart "$CONTAINER_NAME" >/dev/null
+
+echo "Waiting for entrypoint to complete (second boot)..."
+if ! wait_for_entrypoint_count 2; then
+  exit 1
+fi
+
+# The entrypoint messages from the second boot are interleaved with the
+# first boot's messages in the Docker log.  We extract only the messages
+# from after the restart by finding everything after the last "Waiting
+# for Keycloak to start" message.  The awk command resets its buffer
+# each time it sees the marker, so at the end only the final block
+# (the second boot) remains.
+SECOND_BOOT_LOGS=$(docker logs "$CONTAINER_NAME" 2>&1 \
+  | grep "\[entrypoint\]" \
+  | awk '/Waiting for Keycloak to start/{buf=""} {buf=buf $0 "\n"} END{printf "%s", buf}')
+
+echo ""
+echo "--- Idempotency assertions ---"
+
+assert_contains \
+  "Realm import was skipped on restart" \
+  "already exists" \
+  "$SECOND_BOOT_LOGS"
+
+assert_contains \
+  "Mapper fix was skipped on restart" \
+  "already correct" \
+  "$SECOND_BOOT_LOGS"
+
+assert_contains \
+  "Entrypoint completed on restart" \
+  "Realm configuration complete" \
+  "$SECOND_BOOT_LOGS"
+
+# --- Verify state is still correct after restart ---
+#
+# Re-check the mapper and URIs to confirm the restart did not corrupt
+# or revert any configuration.
+
+echo ""
+echo "--- Post-restart state assertions ---"
+
+# Re-authenticate (session from Phase 1 may have expired)
+MAPPER_JSON_2=$(kcadm get \
+  "client-scopes/$PROFILE_SCOPE_ID/protocol-mappers/models/$MAPPER_ID" \
+  -r webprotege)
+
+assert_eq \
+  "Mapper still correct after restart" \
+  "webprotege_username" \
+  "$(echo "$MAPPER_JSON_2" | jq -r '.config["user.attribute"]')"
+
+CLIENT_JSON_2=$(kcadm get "clients/$CLIENT_ID" \
+  -r webprotege --fields baseUrl)
+
+assert_eq \
+  "Client baseUrl still correct after restart" \
+  "http://${TEST_HOST}" \
+  "$(echo "$CLIENT_JSON_2" | jq -r '.baseUrl')"
+
+FRONTEND_URL_2=$(kcadm get realms/webprotege --fields 'attributes(frontendUrl)' \
+  | jq -r '.attributes.frontendUrl')
+
+assert_eq \
+  "Realm frontendUrl still correct after restart" \
+  "http://${TEST_HOST}/keycloak" \
+  "$FRONTEND_URL_2"
+
+# ===========================================================================
+# Results
+# ===========================================================================
+
+echo ""
+echo "==========================================="
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+  echo -e "${GREEN}All ${TOTAL} tests passed.${NC}"
+  exit 0
+else
+  echo -e "${RED}${FAIL} of ${TOTAL} tests failed.${NC}"
+  exit 1
+fi

--- a/webprotege.json
+++ b/webprotege.json
@@ -313,7 +313,8 @@
           "composite": false,
           "clientRole": true,
           "containerId": "d99fbcdd-a2bf-4156-be13-bd5cf07039d4",
-          "attributes": {}
+          "attributes": {},
+          "description": "Grants full administrative access to WebProtege. Assigning this role to a user adds the application-level capabilities required to manage global settings, user accounts, role assignments, and to perform any other admin-only operation.\n\nUse this role to bootstrap the first admin after a fresh install: assign it to one user through the Keycloak admin console, then that user can manage all further role assignments from within WebProtege itself.\n\nTechnical detail: the webprotege-authorization-service reads resource_access.webprotege.roles from the JWT on every request and maps role names to capabilities via BuiltInRoleOracle. 'SystemAdmin' maps to BuiltInRole.SYSTEM_ADMIN, which is a composite role whose closure includes UserAdmin, ProjectCreator, ProjectUploader, AccountCreator and all their capabilities (EditApplicationSettings, RebuildPermissions, ViewAnyUserDetails, DeleteAnyAccount, ResetAnyUserPassword, MoveAnyProjectToTrash, SubstituteUser, CreateEmptyProject, UploadProject, CreateAccount)."
         }
       ],
       "user-management": [],

--- a/webprotege.json
+++ b/webprotege.json
@@ -320,25 +320,6 @@
       "security-admin-console": [],
       "machine-client": [],
       "admin-cli": [],
-      "Icatx_application": [
-        {
-          "id": "03e5aaad-342c-45ac-bae3-9e235933b717",
-          "name": "uma_protection",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "12a189c5-8864-492e-a94a-52512eee9306",
-          "attributes": {}
-        },
-        {
-          "id": "33993a1c-c933-401e-8b99-afd7aa07943c",
-          "name": "ICAT_APPLICATION",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "12a189c5-8864-492e-a94a-52512eee9306",
-          "attributes": {}
-        }
-      ],
       "account-console": [],
       "broker": [],
       "account": [
@@ -423,28 +404,6 @@
   "webAuthnPolicyPasswordlessAcceptableAaguids": [],
   "webAuthnPolicyPasswordlessExtraOrigins": [],
   "users": [
-    {
-      "id": "e58d95bb-5215-44f4-9de6-6281592c1349",
-      "username": "service-account-icatx_application",
-      "emailVerified": false,
-      "createdTimestamp": 1743767598887,
-      "enabled": true,
-      "totp": false,
-      "serviceAccountClientId": "Icatx_application",
-      "disableableCredentialTypes": [],
-      "requiredActions": [],
-      "realmRoles": [
-        "default-roles-webprotege"
-      ],
-      "clientRoles": {
-        "Icatx_application": [
-          "uma_protection",
-          "ICAT_APPLICATION"
-        ]
-      },
-      "notBefore": 0,
-      "groups": []
-    },
     {
       "id": "726b809e-72e4-4502-b81e-cb66f79a2eec",
       "username": "service-account-admin-cli",
@@ -537,81 +496,6 @@
     ]
   },
   "clients": [
-    {
-      "id": "12a189c5-8864-492e-a94a-52512eee9306",
-      "clientId": "Icatx_application",
-      "name": "",
-      "description": "",
-      "rootUrl": "",
-      "adminUrl": "",
-      "baseUrl": "",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "secret": "**********",
-      "redirectUris": [
-        "http://webprotege-local.edu/*"
-      ],
-      "webOrigins": [
-        "http://webprotege-local.edu"
-      ],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": true,
-      "serviceAccountsEnabled": true,
-      "authorizationServicesEnabled": true,
-      "publicClient": false,
-      "frontchannelLogout": true,
-      "protocol": "openid-connect",
-      "attributes": {
-        "realm_client": "false",
-        "oidc.ciba.grant.enabled": "false",
-        "client.secret.creation.time": "1743767598",
-        "backchannel.logout.session.required": "true",
-        "oauth2.device.authorization.grant.enabled": "false",
-        "backchannel.logout.revoke.offline.tokens": "false"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
-      "nodeReRegistrationTimeout": -1,
-      "defaultClientScopes": [
-        "web-origins",
-        "service_account",
-        "acr",
-        "roles",
-        "profile",
-        "basic",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access",
-        "microprofile-jwt"
-      ],
-      "authorizationSettings": {
-        "allowRemoteResourceManagement": true,
-        "policyEnforcementMode": "ENFORCING",
-        "resources": [
-          {
-            "name": "Default Resource",
-            "type": "urn:Icatx_application:resources:default",
-            "ownerManagedAccess": false,
-            "attributes": {},
-            "uris": [
-              "/*"
-            ]
-          }
-        ],
-        "policies": [],
-        "scopes": [],
-        "decisionStrategy": "UNANIMOUS"
-      }
-    },
     {
       "id": "fcb17f7e-6208-443c-86cc-84ff3d503db1",
       "clientId": "account",

--- a/webprotege.json
+++ b/webprotege.json
@@ -524,7 +524,8 @@
         "phone",
         "offline_access",
         "microprofile-jwt"
-      ]
+      ],
+      "description": "Keycloak built-in client. Backs the user self-service account page at /realms/webprotege/account/ (change password, update profile, view active sessions)."
     },
     {
       "id": "cf517ac7-282b-400c-a231-2492868267f7",
@@ -581,7 +582,8 @@
         "phone",
         "offline_access",
         "microprofile-jwt"
-      ]
+      ],
+      "description": "Keycloak built-in client. Backs the modern Keycloak account management console UI, the React-based replacement for the classic /account page."
     },
     {
       "id": "4da7cc98-66d3-44d3-b7ae-3ed981adf1b5",
@@ -694,7 +696,8 @@
         "phone",
         "offline_access",
         "microprofile-jwt"
-      ]
+      ],
+      "description": "Keycloak built-in client. Used by kcadm.sh for realm administration from the command line. The WebProtege entrypoint authenticates as this client when applying post-import realm patches."
     },
     {
       "id": "a0bb6442-27e5-44f3-87f3-8af6109e3eff",
@@ -734,7 +737,8 @@
         "phone",
         "offline_access",
         "microprofile-jwt"
-      ]
+      ],
+      "description": "Keycloak built-in client. Used internally when brokering identities from external OIDC/SAML providers. Required by Keycloak even when no external identity providers are configured."
     },
     {
       "id": "02dad5bf-1f7c-455d-93ee-5950f7e89631",
@@ -774,7 +778,8 @@
         "phone",
         "offline_access",
         "microprofile-jwt"
-      ]
+      ],
+      "description": "Keycloak built-in client. Exposes the Keycloak Admin REST API for this realm. Confidential clients acquire tokens for this client to manage realm objects programmatically (see user-management)."
     },
     {
       "id": "2d8006e4-c3f6-4b17-a4d5-7774d737a994",
@@ -841,13 +846,14 @@
         "phone",
         "offline_access",
         "microprofile-jwt"
-      ]
+      ],
+      "description": "Keycloak built-in client. Backs the Keycloak Admin Console UI at /admin/ where realm administrators manage users, roles, clients, and realm-level configuration."
     },
     {
       "id": "ac4a2ffb-4677-44bf-9bb8-551e965142c6",
       "clientId": "user-management",
       "name": "User Management",
-      "description": "This client is used by user management microservice to fetch user data.",
+      "description": "Confidential OIDC client used by webprotege-user-management-service to call the Keycloak Admin API (user CRUD, password resets, role assignments). Client secret is wired through .env as ADMIN_CLI_SECRET.",
       "rootUrl": "",
       "adminUrl": "",
       "baseUrl": "",
@@ -913,7 +919,7 @@
       "id": "d99fbcdd-a2bf-4156-be13-bd5cf07039d4",
       "clientId": "webprotege",
       "name": "WebProt\u00e9g\u00e9",
-      "description": "Represents the WebProt\u00e9g\u00e9 UI",
+      "description": "Public OIDC client for the WebProtege web UI. Users authenticate against this client during login and registration. Its protocol mappers shape the JWT claims that downstream services read (preferred_username, email).",
       "rootUrl": "",
       "adminUrl": "",
       "baseUrl": "http://webprotege-local.edu",

--- a/webprotege.json
+++ b/webprotege.json
@@ -314,7 +314,7 @@
           "clientRole": true,
           "containerId": "d99fbcdd-a2bf-4156-be13-bd5cf07039d4",
           "attributes": {},
-          "description": "Grants full administrative access to WebProtege. Assigning this role to a user adds the application-level capabilities required to manage global settings, user accounts, role assignments, and to perform any other admin-only operation.\n\nUse this role to bootstrap the first admin after a fresh install: assign it to one user through the Keycloak admin console, then that user can manage all further role assignments from within WebProtege itself.\n\nTechnical detail: the webprotege-authorization-service reads resource_access.webprotege.roles from the JWT on every request and maps role names to capabilities via BuiltInRoleOracle. 'SystemAdmin' maps to BuiltInRole.SYSTEM_ADMIN, which is a composite role whose closure includes UserAdmin, ProjectCreator, ProjectUploader, AccountCreator and all their capabilities (EditApplicationSettings, RebuildPermissions, ViewAnyUserDetails, DeleteAnyAccount, ResetAnyUserPassword, MoveAnyProjectToTrash, SubstituteUser, CreateEmptyProject, UploadProject, CreateAccount)."
+          "description": "Grants full admin access to WebProtege. Assign to the first user after a fresh install to bootstrap admin access; that user can then manage further role assignments within WebProtege. Maps to BuiltInRole.SYSTEM_ADMIN via resource_access in the JWT."
         }
       ],
       "user-management": [],

--- a/webprotege.json
+++ b/webprotege.json
@@ -1,8 +1,8 @@
 {
   "id": "webprotege",
   "realm": "webprotege",
-  "displayName": "WebProtégé",
-  "displayNameHtml": "WebProtégé",
+  "displayName": "WebProt\u00e9g\u00e9",
+  "displayNameHtml": "WebProt\u00e9g\u00e9",
   "notBefore": 1706186910,
   "defaultSignatureAlgorithm": "RS256",
   "revokeRefreshToken": false,
@@ -50,15 +50,6 @@
   "roles": {
     "realm": [
       {
-        "id": "8a5547b8-dc0e-4a4a-b6dd-c0f3622c3efa",
-        "name": "SYSTEM_ADMIN",
-        "description": "",
-        "composite": false,
-        "clientRole": false,
-        "containerId": "webprotege",
-        "attributes": {}
-      },
-      {
         "id": "561b67b1-3f65-4d7b-9814-57b302ca0cdb",
         "name": "uma_authorization",
         "description": "${role_uma_authorization}",
@@ -76,14 +67,9 @@
           "realm": [
             "offline_access",
             "uma_authorization",
-            "user",
-            "SYSTEM_ADMIN"
+            "user"
           ],
-          "client": {
-            "webprotege": [
-              "user"
-            ]
-          }
+          "client": {}
         },
         "clientRole": false,
         "containerId": "webprotege",
@@ -101,14 +87,6 @@
       {
         "id": "24adc185-0e79-43a9-a511-32c4a382c3cc",
         "name": "user",
-        "composite": false,
-        "clientRole": false,
-        "containerId": "webprotege",
-        "attributes": {}
-      },
-      {
-        "id": "0d5dab56-fc48-4e75-b5d2-a09f1dff59ee",
-        "name": "admin",
         "composite": false,
         "clientRole": false,
         "containerId": "webprotege",
@@ -330,50 +308,8 @@
       ],
       "webprotege": [
         {
-          "id": "9af3e966-9a70-467e-9713-596fe71b1cfc",
-          "name": "user",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "d99fbcdd-a2bf-4156-be13-bd5cf07039d4",
-          "attributes": {}
-        },
-        {
-          "id": "bcd9d658-2d68-4dc0-a4e9-0db4399fdd7b",
-          "name": "admin",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "d99fbcdd-a2bf-4156-be13-bd5cf07039d4",
-          "attributes": {}
-        },
-        {
           "id": "c96478e5-e778-4aad-941a-eb9a9b3abda7",
           "name": "SystemAdmin",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "d99fbcdd-a2bf-4156-be13-bd5cf07039d4",
-          "attributes": {}
-        },
-        {
-          "id": "83399375-fb11-44f3-b3e8-f8c8a45a41bf",
-          "name": "ICAT_APPLICATION",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "d99fbcdd-a2bf-4156-be13-bd5cf07039d4",
-          "attributes": {}
-        },
-        {
-          "id": "f3ffa0df-7bd9-42ac-8863-98a1574234b6",
-          "name": "ProjectCreator",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "d99fbcdd-a2bf-4156-be13-bd5cf07039d4",
-          "attributes": {}
-        },
-        {
-          "id": "67c5acde-af15-40b8-9616-089c9aa59259",
-          "name": "ProjectManager",
-          "description": "someone that can manage the entire project",
           "composite": false,
           "clientRole": true,
           "containerId": "d99fbcdd-a2bf-4156-be13-bd5cf07039d4",
@@ -501,9 +437,6 @@
         "default-roles-webprotege"
       ],
       "clientRoles": {
-        "webprotege": [
-          "ICAT_APPLICATION"
-        ],
         "Icatx_application": [
           "uma_protection",
           "ICAT_APPLICATION"
@@ -1222,8 +1155,8 @@
     {
       "id": "d99fbcdd-a2bf-4156-be13-bd5cf07039d4",
       "clientId": "webprotege",
-      "name": "WebProtégé",
-      "description": "Represents the WebProtégé UI",
+      "name": "WebProt\u00e9g\u00e9",
+      "description": "Represents the WebProt\u00e9g\u00e9 UI",
       "rootUrl": "",
       "adminUrl": "",
       "baseUrl": "http://webprotege-local.edu",

--- a/webprotege.json
+++ b/webprotege.json
@@ -319,7 +319,6 @@
       ],
       "user-management": [],
       "security-admin-console": [],
-      "machine-client": [],
       "admin-cli": [],
       "account-console": [],
       "broker": [],
@@ -432,22 +431,6 @@
           "view-authorization"
         ]
       },
-      "notBefore": 0,
-      "groups": []
-    },
-    {
-      "id": "b2a6c7a6-4645-449e-9c7f-5b09d1d03a18",
-      "username": "service-account-machine-client",
-      "emailVerified": false,
-      "createdTimestamp": 1711102081285,
-      "enabled": true,
-      "totp": false,
-      "serviceAccountClientId": "machine-client",
-      "disableableCredentialTypes": [],
-      "requiredActions": [],
-      "realmRoles": [
-        "default-roles-webprotege"
-      ],
       "notBefore": 0,
       "groups": []
     },
@@ -744,117 +727,6 @@
         "web-origins",
         "roles",
         "profile",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access",
-        "microprofile-jwt"
-      ]
-    },
-    {
-      "id": "16182e75-f660-405e-bf3e-9391c24c1aa4",
-      "clientId": "machine-client",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "secret": "**********",
-      "redirectUris": [],
-      "webOrigins": [],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": true,
-      "serviceAccountsEnabled": true,
-      "publicClient": false,
-      "frontchannelLogout": false,
-      "protocol": "openid-connect",
-      "attributes": {
-        "id.token.as.detached.signature": "false",
-        "saml.assertion.signature": "false",
-        "saml.force.post.binding": "false",
-        "saml.multivalued.roles": "false",
-        "saml.encrypt": "false",
-        "post.logout.redirect.uris": "+",
-        "oauth2.device.authorization.grant.enabled": "false",
-        "backchannel.logout.revoke.offline.tokens": "false",
-        "saml.server.signature": "false",
-        "saml.server.signature.keyinfo.ext": "false",
-        "use.refresh.tokens": "true",
-        "exclude.session.state.from.auth.response": "false",
-        "realm_client": "false",
-        "oidc.ciba.grant.enabled": "false",
-        "saml.artifact.binding": "false",
-        "backchannel.logout.session.required": "true",
-        "client_credentials.use_refresh_token": "false",
-        "saml_force_name_id_format": "false",
-        "require.pushed.authorization.requests": "false",
-        "saml.client.signature": "false",
-        "tls.client.certificate.bound.access.tokens": "false",
-        "saml.authnstatement": "false",
-        "display.on.consent.screen": "false",
-        "saml.onetimeuse.condition": "false"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
-      "nodeReRegistrationTimeout": -1,
-      "protocolMappers": [
-        {
-          "id": "ff467eba-a954-45a3-98ff-cef4d9a21d7c",
-          "name": "Client ID",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientId",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientId",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
-          }
-        },
-        {
-          "id": "eabd59f4-9e76-43f6-bec6-a50ba2d48ab8",
-          "name": "Client Host",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientHost",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientHost",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
-          }
-        },
-        {
-          "id": "05b061fa-5345-4491-8e84-8898598129b5",
-          "name": "Client IP Address",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientAddress",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientAddress",
-            "jsonType.label": "String",
-            "userinfo.token.claim": "true"
-          }
-        }
-      ],
-      "defaultClientScopes": [
-        "web-origins",
-        "acr",
-        "roles",
-        "profile",
-        "basic",
         "email"
       ],
       "optionalClientScopes": [

--- a/webprotege.json
+++ b/webprotege.json
@@ -1949,7 +1949,8 @@
   "emailTheme": "keycloak",
   "eventsEnabled": true,
   "eventsListeners": [
-    "jboss-logging"
+    "jboss-logging",
+    "webprotege-username-attribute"
   ],
   "enabledEventTypes": [
     "SEND_RESET_PASSWORD",


### PR DESCRIPTION
## Summary

This PR eliminates the manual Keycloak setup steps that operators currently have to perform after deploying WebProtege. It also modernises the build and release process to match the patterns used by other webprotege services.

### Before this PR

After starting Keycloak, operators had to manually:

1. Import the realm via `kcadm.sh create realms` (~1 step)
2. Delete and recreate the `username` protocol mapper across 4 sub-steps because Keycloak's realm import silently drops the mapper config ([keycloak#36065](https://github.com/keycloak/keycloak/issues/36065), [keycloak#16289](https://github.com/keycloak/keycloak/issues/16289))
3. Verify the mapper was correct (~1 step)

Self-hosted deployments also had to manually edit the realm JSON or run kcadm commands to update redirect URIs, web origins, and the frontend URL to match their hostname.

Building the Docker image required Java and Maven installed locally to compile the SPI plugin before running `docker build`.

### After this PR

Keycloak starts, imports the realm, fixes the mapper, and configures all URIs automatically. The operator just sets `SERVER_HOST` and runs `docker compose up`.

Building the image requires only Docker — `docker build .` handles everything.

## What changed

### Entrypoint script (`entrypoint.sh`)

A bash wrapper around `kc.sh` that runs after Keycloak starts:

1. **Realm import** — imports the `webprotege` realm via kcadm if it doesn't already exist. Keycloak does not auto-import from `/opt/keycloak/import/`; the entrypoint handles this explicitly.
2. **Protocol mapper fix** — checks whether the `username` mapper in the `profile` client scope correctly maps `webprotege_username` to `preferred_username`. If not, deletes and recreates it. This works around a Keycloak bug where the import drops the mapper's config dict.
3. **Hostname-based URI patching** — when `SERVER_HOST` is set, updates the `webprotege` client's `baseUrl`, `redirectUris`, `webOrigins`, and the realm's `frontendUrl` to match. This makes the image portable across local dev, staging, and production.

All operations are idempotent — on subsequent restarts, the script detects the correct state and skips modifications. SIGTERM/SIGINT are forwarded to the Keycloak process for graceful shutdown.

### Multi-stage Dockerfile

- **SPI build stage** — compiles the authenticator plugin inside Docker using `maven:3.9-eclipse-temurin-17`. No local Java or Maven needed.
- **jq download stage** — fetches a static `jq` binary from GitHub releases (architecture-aware via `TARGETARCH`). Used by the entrypoint to parse kcadm JSON output.
- **Final stage** — based on `keycloak/keycloak:26.1` as before, with the entrypoint set as the image's `ENTRYPOINT`.

### Integration test (`test-entrypoint.sh`)

A self-contained test script that verifies the entrypoint end-to-end:

- Starts the container with a test `SERVER_HOST`
- Asserts: realm imported, mapper config correct, client URIs rewritten, frontend URL updated
- Restarts the container with a persistent volume
- Asserts: realm import skipped, mapper fix skipped, state unchanged

15 assertions total, runs in ~60 seconds. No host port needed (all checks run inside the container via `docker exec`).

### CI/CD workflows

Aligned with the pattern used by other webprotege services:

- **`ci.yaml`** — runs on feature branches and PRs. Builds the image and runs the integration test.
- **`release.yaml`** — triggers on merge to main. Reads the version from `pom.xml`, strips `-SNAPSHOT`, releases that version, then bumps patch and adds `-SNAPSHOT` back for the next development cycle. Includes the integration test as a gate before pushing to Docker Hub. Notifies the deploy repo after a successful release.
- **`notify-deploy-project.yaml`** — reusable workflow that triggers `update-compose.yml` in `webprotege-deploy` to update the image version in `docker-compose.yml`.

### Versioning

Follows the standard Maven `-SNAPSHOT` convention:

- `pom.xml` contains the next intended version with `-SNAPSHOT` (e.g. `2.0.0-SNAPSHOT`)
- On merge to main, the workflow strips `-SNAPSHOT` and releases that version (`2.0.0`)
- After release, the workflow bumps patch and sets `2.0.1-SNAPSHOT`
- Major/minor bumps: set the pom to `X.Y.0-SNAPSHOT` on your branch before merging

### Branch protection

Added a "Protect Main" ruleset matching `webprotege-backend-service`: no deletion, no force push, PRs required, bot bypass for release commits.

## Test plan

- [x] Docker image builds successfully (`docker build .`)
- [x] Integration test passes locally (15/15 assertions)
- [x] First boot: realm imported, mapper correct, URIs patched
- [x] Restart with volume: import skipped, mapper skipped, state preserved
- [x] No host port required (no port conflicts)
- [ ] CI workflow runs on this PR