### PR TITLE
Require email verification at registration (fixes #9)

### DIFF
--- a/webprotege.json
+++ b/webprotege.json
@@ -32,7 +32,7 @@
   "registrationAllowed": true,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
-  "verifyEmail": false,
+  "verifyEmail": true,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,
   "resetPasswordAllowed": true,


### PR DESCRIPTION
## Problem

The `webprotege` realm allows open self-registration with the email address as the username, but `verifyEmail` is off — so nothing ever proves that a person owns the address they registered with. An unverified account can claim any email as its identity.

## Change

One line in `webprotege.json`: `"verifyEmail": false` → `true`.

## Effect

- New registrations receive a verification email and must click the link before their first login completes, so `email_verified=true` in tokens actually means inbox ownership.
- Pending sharing invitations (protegeproject/webprotege-backend-service#177 / PR protegeproject/webprotege-backend-service#182) redeem only against a verified email claim; with this flag on, the whole flow is automatic — register, verify, log in, and the shared project appears — with no admin intervention.
- Existing accounts that are not yet verified will be asked to verify at their next login.
- The realm's user-initiated action-token lifespan (300s) governs link expiry, and Keycloak offers re-sending from the login screen. The realm's SMTP settings must point at a working mail server (the docker-compose deployment already routes to Mailpit).